### PR TITLE
Added support for downloading generic NSData, not just UIImage.

### DIFF
--- a/AsyncImageDownloader.h
+++ b/AsyncImageDownloader.h
@@ -2,22 +2,27 @@
 //  AsyncImageDownloader.h
 //
 //  Created by Kyle Banks on 2012-11-29.
+//  Modified by Nicolas Schteinschraber 2013-05-30
 //
 
 #import <Foundation/Foundation.h>
 
 @interface AsyncImageDownloader : NSObject <NSURLConnectionDelegate>
 {
-    NSMutableData *imageData;
+    NSMutableData *fileData;
     
     //Callback blocks
+    void (^successCallbackFile)(NSData *data);
     void (^successCallback)(UIImage *image);
     void (^failCallback)(NSError *error);
 }
 
 @property NSString *mediaURL;
+@property NSString *fileURL;
 
 -(id)initWithMediaURL:(NSString *)theMediaURL successBlock:(void (^)(UIImage *image))success failBlock:(void(^)(NSError *error))fail;
+
+-(id)initWithFileURL:(NSString *)theFileURL successBlock:(void (^)(NSData *data))success failBlock:(void(^)(NSError *error))fail;
 
 -(void)startDownload;
 


### PR DESCRIPTION
Added "-(id)initWithFileURL:(NSString *) successBlock:(void (^)(NSData
*data)) failBlock:(void(^)(NSError *error))" that has a success block
with NSData as param.
